### PR TITLE
Install headers to include/${PROJECT_NAME}

### DIFF
--- a/orocos_kdl_vendor/0001-include_project_name.patch
+++ b/orocos_kdl_vendor/0001-include_project_name.patch
@@ -1,0 +1,23 @@
+diff --git a/orocos_kdl/src/CMakeLists.txt b/orocos_kdl/src/CMakeLists.txt
+index 954b8fc..306187a 100644
+--- a/orocos_kdl/src/CMakeLists.txt
++++ b/orocos_kdl/src/CMakeLists.txt
+@@ -53,7 +53,7 @@ ENDIF()
+ ADD_LIBRARY(orocos-kdl ${LIB_TYPE} ${KDL_SRCS})
+ 
+ TARGET_INCLUDE_DIRECTORIES(orocos-kdl PUBLIC
+-  "$<INSTALL_INTERFACE:include>")
++  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+ 
+ SET_TARGET_PROPERTIES( orocos-kdl PROPERTIES
+   SOVERSION "${KDL_VERSION_MAJOR}.${KDL_VERSION_MINOR}"
+@@ -79,7 +79,7 @@ INSTALL(TARGETS orocos-kdl
+   ARCHIVE DESTINATION lib${LIB_SUFFIX}
+   LIBRARY DESTINATION lib${LIB_SUFFIX}
+   RUNTIME DESTINATION bin
+-  PUBLIC_HEADER DESTINATION include/kdl
++  PUBLIC_HEADER DESTINATION include/${PROJECT_NAME}/kdl
+ )
+ 
+-INSTALL(FILES ${UTIL_HPPS} DESTINATION include/kdl/utilities)
++INSTALL(FILES ${UTIL_HPPS} DESTINATION include/${PROJECT_NAME}/kdl/utilities)

--- a/orocos_kdl_vendor/CMakeLists.txt
+++ b/orocos_kdl_vendor/CMakeLists.txt
@@ -53,14 +53,21 @@ macro(build_orocos_kdl)
   include(ExternalProject)
 
   # Build orocos_kdl
-  externalproject_add(orocos_kdl
-    URL https://github.com/orocos/orocos_kinematics_dynamics/archive/507de66205e14b12c8c65f25eafc05c4dc66e21e.zip
-    URL_MD5 3f547798ab4461b8247fb764435f3623
+  externalproject_add(orocos_kdl-507de66
+    GIT_REPOSITORY https://github.com/orocos/orocos_kinematics_dynamics.git
+    GIT_TAG 507de66205e14b12c8c65f25eafc05c4dc66e21e  # 1.5.1 + yet-to-be-released commits
+    GIT_CONFIG advice.detachedHead=false
+    # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
+    # See https://github.com/ament/uncrustify_vendor/pull/22 for details
+    UPDATE_COMMAND ""
     TIMEOUT 600
     SOURCE_SUBDIR orocos_kdl
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
       ${extra_cmake_args}
+    PATCH_COMMAND
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn
+        ${CMAKE_CURRENT_SOURCE_DIR}/0001-include_project_name.patch
   )
 
   # The external project will install to the build folder, but we'll install that on make install.


### PR DESCRIPTION
Part of ros2/ros2#1150 - this patches `orocos-kdl` to install it's headers to a unique include directory. This avoids include directory search order issues when overriding packages.

Requires https://github.com/ros2/ros2/pull/1208 to be able to run CI