### PR TITLE
Ensure orocos-kdl target references Eigen

### DIFF
--- a/orocos_kdl_vendor/CMakeLists.txt
+++ b/orocos_kdl_vendor/CMakeLists.txt
@@ -90,4 +90,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_package()
+ament_package(CONFIG_EXTRAS "orocos_kdl_vendor-extras.cmake")

--- a/orocos_kdl_vendor/orocos_kdl_vendor-extras.cmake
+++ b/orocos_kdl_vendor/orocos_kdl_vendor-extras.cmake
@@ -1,0 +1,26 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+find_package(eigen3_cmake_module REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(orocos_kdl REQUIRED)
+if(TARGET orocos-kdl)
+  message(STATUS "Ensuring Eigen3 include directory is part of orocos-kdl CMake target")
+  if(TARGET Eigen3::Eigen)
+    # TODO: require target to exist when https://github.com/ros2/choco-packages/issues/19 is addressed
+    target_link_libraries(orocos-kdl INTERFACE Eigen3::Eigen)
+  else()
+    target_include_directories(orocos-kdl SYSTEM INTERFACE ${Eigen3_INCLUDE_DIRS})
+  endif()
+endif()


### PR DESCRIPTION
Paris with:
* https://github.com/ros2/geometry2/compare/ros2...cottsay/orocos-eigen-target
* https://github.com/ros/kdl_parser/compare/ros2...cottsay/orocos-eigen-target

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16670)](http://ci.ros2.org/job/ci_linux/16670/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11256)](http://ci.ros2.org/job/ci_linux-aarch64/11256/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=225)](http://ci.ros2.org/job/ci_linux-rhel/225/) 
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17065)](http://ci.ros2.org/job/ci_windows/17065/)

Note that calling `find_package(orocos_kdl)` after `find_package(orocos_kdl_vendor)` is okay because [the target isn't re-created](https://github.com/orocos/orocos_kinematics_dynamics/blob/507de66205e14b12c8c65f25eafc05c4dc66e21e/orocos_kdl/orocos_kdl-config.cmake.in#L21-L23).