### PR TITLE
Workaround pybind11 CMake error

### DIFF
--- a/python_orocos_kdl_vendor/CMakeLists.txt
+++ b/python_orocos_kdl_vendor/CMakeLists.txt
@@ -31,6 +31,10 @@ if(NOT FORCE_BUILD_VENDOR_PKG)
 endif()
 
 macro(build_pykdl)
+  # Find python before pybind11
+  # Workaround for https://github.com/pybind/pybind11/issues/3996
+  find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+
   include(FetchContent)
 
   # This version must match orocos_kdl_vendor exactly


### PR DESCRIPTION
We can avoid an upstream issue with pybind11 by finding Python3 before PyKDL tries to find pybind11.
Same as patches being applied in other ROS packages, e.g. https://github.com/ros2/rosbag2/pull/945.

---

To reproduce the original CMake error on Ubuntu 20.04, first uninstall `pybind11-dev` from the system, then build this package (and pybind11_vendor) with `--cmake-args -DFORCE_BUILD_VENDOR_PKG=ON`.