### PR TITLE
Ensure orocos-kdl is available as a target

### DIFF
--- a/orocos_kdl_vendor/orocos_kdl_vendor-extras.cmake
+++ b/orocos_kdl_vendor/orocos_kdl_vendor-extras.cmake
@@ -12,15 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+find_package(orocos_kdl REQUIRED)
+if(NOT TARGET orocos-kdl)
+  find_library(orocos_kdl_LIBRARY orocos-kdl REQUIRED)
+  add_library(orocos-kdl SHARED IMPORTED)
+  set_target_properties(orocos-kdl PROPERTIES
+    IMPORTED_LOCATION ${orocos_kdl_LIBRARY}
+    INTERFACE_LINK_LIBRARIES ${orocos_kdl_LIBRARIES}
+    INTERFACE_INCLUDE_DIRECTORIES ${orocos_kdl_INCLUDE_DIRS})
+endif()
+
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(orocos_kdl REQUIRED)
-if(TARGET orocos-kdl)
-  message(STATUS "Ensuring Eigen3 include directory is part of orocos-kdl CMake target")
-  if(TARGET Eigen3::Eigen)
-    # TODO: require target to exist when https://github.com/ros2/choco-packages/issues/19 is addressed
-    target_link_libraries(orocos-kdl INTERFACE Eigen3::Eigen)
-  else()
-    target_include_directories(orocos-kdl SYSTEM INTERFACE ${Eigen3_INCLUDE_DIRS})
-  endif()
+message(STATUS "Ensuring Eigen3 include directory is part of orocos-kdl CMake target")
+if(TARGET Eigen3::Eigen)
+  # TODO: require target to exist when https://github.com/ros2/choco-packages/issues/19 is addressed
+  target_link_libraries(orocos-kdl INTERFACE Eigen3::Eigen)
+else()
+  target_include_directories(orocos-kdl SYSTEM INTERFACE ${Eigen3_INCLUDE_DIRS})
 endif()


### PR DESCRIPTION
#6 ensures that the `orocos-kdl` target exported by Orocos KDL versions newer than 1.5.1 will include the Eigen3 directories. This PR ensures that the target is present by creating a new "imported" library and populating it based on the old-style `_LIBRARIES` and `_INCLUDE_DIRS` variables.

This wasn't caught in the original PR because the `orocos_kdl_vendor` package includes additional changes after 1.5.1 was tagged which export the target, and ci.ros2.org isn't installing `liborocos-kdl-dev`. I was able to reproduce the problem using the build.ros2.org CI jobs.

From build.ros2.org:
* Before [![Build Status](https://build.ros2.org/buildStatus/icon?job=Rci__overlay_ubuntu_jammy_amd64&build=11)](https://build.ros2.org/view/Rci/job/Rci__overlay_ubuntu_jammy_amd64/11/)
* After [![Build Status](https://build.ros2.org/buildStatus/icon?job=Rci__overlay_ubuntu_jammy_amd64&build=13)](https://build.ros2.org/view/Rci/job/Rci__overlay_ubuntu_jammy_amd64/13/)

With CI changes:
* Before [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16874)](http://ci.ros2.org/job/ci_linux/16874/) (this passes because it still has the manual Eigen workarounds in downstream packages)
* After [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16873)](http://ci.ros2.org/job/ci_linux/16873/)

Current CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16868)](http://ci.ros2.org/job/ci_linux/16868/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11445)](http://ci.ros2.org/job/ci_linux-aarch64/11445/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=235)](http://ci.ros2.org/job/ci_linux-rhel/235/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17274)](http://ci.ros2.org/job/ci_windows/17274/)

Paris with:
* ros2/geometry2#534
* ros/kdl_parser#64