### PR TITLE
Make sure to quote orocos variables when setting targets.

### DIFF
--- a/orocos_kdl_vendor/orocos_kdl_vendor-extras.cmake
+++ b/orocos_kdl_vendor/orocos_kdl_vendor-extras.cmake
@@ -17,9 +17,9 @@ if(NOT TARGET orocos-kdl)
   find_library(orocos_kdl_LIBRARY orocos-kdl REQUIRED)
   add_library(orocos-kdl SHARED IMPORTED)
   set_target_properties(orocos-kdl PROPERTIES
-    IMPORTED_LOCATION ${orocos_kdl_LIBRARY}
-    INTERFACE_LINK_LIBRARIES ${orocos_kdl_LIBRARIES}
-    INTERFACE_INCLUDE_DIRECTORIES ${orocos_kdl_INCLUDE_DIRS})
+    IMPORTED_LOCATION "${orocos_kdl_LIBRARY}"
+    INTERFACE_LINK_LIBRARIES "${orocos_kdl_LIBRARIES}"
+    INTERFACE_INCLUDE_DIRECTORIES "${orocos_kdl_INCLUDE_DIRS}")
 endif()
 
 find_package(eigen3_cmake_module REQUIRED)


### PR DESCRIPTION
If the variables happen to have semicolons in them, then an
unquoted version means that we get CMake errors about
set_target_properties having the wrong number of arguments.
Make sure to quote all of the variables.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I noticed this while attempting to build `pcl_ros` locally; I kept getting the aforementioned set_target_properties error.  I don't understand why this wasn't a problem while building https://build.ros2.org packages, but only locally.  Still, I think this is the correct fix.