### PR TITLE
Fixes policy CMP0135 warning for CMake >= 3.24

### DIFF
--- a/python_orocos_kdl_vendor/CMakeLists.txt
+++ b/python_orocos_kdl_vendor/CMakeLists.txt
@@ -10,7 +10,7 @@ option(FORCE_BUILD_VENDOR_PKG
 
 # Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
 if (POLICY CMP0135)
-  cmake_policy(SET CMP0135 OLD)
+  cmake_policy(SET CMP0135 NEW)
 endif()
 
 if(NOT FORCE_BUILD_VENDOR_PKG)

--- a/python_orocos_kdl_vendor/CMakeLists.txt
+++ b/python_orocos_kdl_vendor/CMakeLists.txt
@@ -8,6 +8,11 @@ option(FORCE_BUILD_VENDOR_PKG
   "Build python_orocos_kdl from source, even if system-installed package is available"
   OFF)
 
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
+if (POLICY CMP0135)
+  cmake_policy(SET CMP0135 OLD)
+endif()
+
 if(NOT FORCE_BUILD_VENDOR_PKG)
   # Check if Python bindings are installed by trying to import from interpreter
   # Figure out Python3 debug/release before anything else can find_package it

--- a/python_orocos_kdl_vendor/CMakeLists.txt
+++ b/python_orocos_kdl_vendor/CMakeLists.txt
@@ -9,7 +9,7 @@ option(FORCE_BUILD_VENDOR_PKG
   OFF)
 
 # Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
-if (POLICY CMP0135)
+if(POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)
 endif()
 


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

Reference build: https://ci.ros2.org/view/nightly/job/nightly_win_deb/2473/

[This](https://cmake.org/cmake/help/latest/policy/CMP0135.html) warning started appearing on new windows machines. It’s caused by a new CMake version (3.24) that expects this policy to be set.

This PR sets CMP0135 policy in CMakeLists.txt
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17260)](http://ci.ros2.org/job/ci_linux/17260/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11799)](http://ci.ros2.org/job/ci_linux-aarch64/11799/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17740)](http://ci.ros2.org/job/ci_windows/17740/)