### PR TITLE
Adds `find_package(eigen3_cmake_module)` to resolve eigen3 path

### DIFF
--- a/orocos_kdl_vendor/CMakeLists.txt
+++ b/orocos_kdl_vendor/CMakeLists.txt
@@ -3,7 +3,7 @@ project(orocos_kdl_vendor)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
-
+find_package(eigen3_cmake_module REQUIRED)
 # Set minimum version to find matching what would be built because PyKDL vendor will require it
 find_package(orocos_kdl 1.5.1 QUIET)
 


### PR DESCRIPTION
Was building on a new windows 11 machine when this package gave me an error stating cmake could not find eigen3.
Seems like the eigen variables were not set properly. This commit addresses this issue by relying on eigen3_cmake_module.

TBH, I have no idea if this is the correct approach to resolving the issue.