### PR TITLE
Update to the latest orocos_kdl_kinematics commit.

### DIFF
--- a/orocos_kdl_vendor/CMakeLists.txt
+++ b/orocos_kdl_vendor/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(orocos_kdl 1.5.1 QUIET)
 ament_vendor(orocos_kdl_vendor
   SATISFIED ${orocos_kdl_FOUND}
   VCS_URL https://github.com/orocos/orocos_kinematics_dynamics.git
-  VCS_VERSION 507de66205e14b12c8c65f25eafc05c4dc66e21e
+  VCS_VERSION ce4bcb65a050615b6d7f21bc60fbb2656515791b
   SOURCE_SUBDIR orocos_kdl
   GLOBAL_HOOK
   CMAKE_ARGS

--- a/python_orocos_kdl_vendor/CMakeLists.txt
+++ b/python_orocos_kdl_vendor/CMakeLists.txt
@@ -47,6 +47,9 @@ macro(build_pykdl)
     python_orocos_kdl
     URL https://github.com/orocos/orocos_kinematics_dynamics/archive/ce4bcb65a050615b6d7f21bc60fbb2656515791b.zip
     URL_MD5 f273799921a2fd21b79211c93fa67a5d
+    PATCH_COMMAND
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn
+        ${CMAKE_CURRENT_SOURCE_DIR}/patches/0001-fix-windows-debug.patch
   )
 
   fetchcontent_getproperties(python_orocos_kdl)

--- a/python_orocos_kdl_vendor/CMakeLists.txt
+++ b/python_orocos_kdl_vendor/CMakeLists.txt
@@ -45,8 +45,8 @@ macro(build_pykdl)
   # This version must match orocos_kdl_vendor exactly
   fetchcontent_declare(
     python_orocos_kdl
-    URL https://github.com/orocos/orocos_kinematics_dynamics/archive/507de66205e14b12c8c65f25eafc05c4dc66e21e.zip
-    URL_MD5 3f547798ab4461b8247fb764435f3623
+    URL https://github.com/orocos/orocos_kinematics_dynamics/archive/ce4bcb65a050615b6d7f21bc60fbb2656515791b.zip
+    URL_MD5 f273799921a2fd21b79211c93fa67a5d
   )
 
   fetchcontent_getproperties(python_orocos_kdl)

--- a/python_orocos_kdl_vendor/patches/0001-fix-windows-debug.patch
+++ b/python_orocos_kdl_vendor/patches/0001-fix-windows-debug.patch
@@ -5,9 +5,9 @@
  
  find_package(Python ${PYTHON_VERSION} COMPONENTS Interpreter Development REQUIRED)
 +if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-+  get_filename_component(_python_executable_dir "${PYTHON_EXECUTABLE}" DIRECTORY)
-+  get_filename_component(_python_executable_name "${PYTHON_EXECUTABLE}" NAME_WE)
-+  get_filename_component(_python_executable_ext "${PYTHON_EXECUTABLE}" EXT)
++  get_filename_component(_python_executable_dir "${Python_EXECUTABLE}" DIRECTORY)
++  get_filename_component(_python_executable_name "${Python_EXECUTABLE}" NAME_WE)
++  get_filename_component(_python_executable_ext "${Python_EXECUTABLE}" EXT)
 +  set(_python_executable_debug "${_python_executable_dir}/${_python_executable_name}_d${_python_executable_ext}")
 +  if(EXISTS "${_python_executable_debug}")
 +    set(Python_EXECUTABLE "${_python_executable_debug}")

--- a/python_orocos_kdl_vendor/patches/0001-fix-windows-debug.patch
+++ b/python_orocos_kdl_vendor/patches/0001-fix-windows-debug.patch
@@ -1,0 +1,20 @@
+--- a/python_orocos_kdl/CMakeLists.txt	2023-12-08 15:19:53.469243534 +0000
++++ b/python_orocos_kdl/CMakeLists.txt	2023-12-08 15:20:18.110104659 +0000
+@@ -26,6 +26,17 @@ endif()
+ set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION} CACHE STRING "Python version used by PyBind11")
+ 
+ find_package(Python ${PYTHON_VERSION} COMPONENTS Interpreter Development REQUIRED)
++if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
++  get_filename_component(_python_executable_dir "${PYTHON_EXECUTABLE}" DIRECTORY)
++  get_filename_component(_python_executable_name "${PYTHON_EXECUTABLE}" NAME_WE)
++  get_filename_component(_python_executable_ext "${PYTHON_EXECUTABLE}" EXT)
++  set(_python_executable_debug "${_python_executable_dir}/${_python_executable_name}_d${_python_executable_ext}")
++  if(EXISTS "${_python_executable_debug}")
++    set(Python_EXECUTABLE "${_python_executable_debug}")
++  else()
++    message(FATAL_ERROR "${_python_executable_debug} doesn't exist")
++  endif()
++endif()
+ # get_python_lib in python3 produces path which isn't in sys.path: https://bugs.launchpad.net/ubuntu/+source/python3-stdlib-extensions/+bug/1832215
+ # execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True, prefix=''))" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+ set(PYTHON_SITE_PACKAGES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/dist-packages")  # This might be overridden below if built with catkin.


### PR DESCRIPTION
The main reason to do it is to quiet down PythonInterp warnings (which are removed in the latest), but also to just generally keep up.