### PR TITLE
Ensure that orocos_kdl_vendor doesn't accidentally find itself.

### DIFF
--- a/orocos_kdl_vendor/CMakeLists.txt
+++ b/orocos_kdl_vendor/CMakeLists.txt
@@ -16,6 +16,7 @@ ament_vendor(orocos_kdl_vendor
   CMAKE_ARGS
     -DENABLE_TESTS:BOOL=OFF
     -DENABLE_EXAMPLES:BOOL=OFF
+  PATCHES patches
 )
 
 if(BUILD_TESTING)

--- a/orocos_kdl_vendor/patches/windows-cmake-3.29-rebuild.patch
+++ b/orocos_kdl_vendor/patches/windows-cmake-3.29-rebuild.patch
@@ -1,0 +1,26 @@
+diff --git a/orocos_kdl/CMakeLists.txt b/orocos_kdl/CMakeLists.txt
+index f9d37e0..2882744 100644
+--- a/orocos_kdl/CMakeLists.txt
++++ b/orocos_kdl/CMakeLists.txt
+@@ -113,14 +113,17 @@ export(TARGETS orocos-kdl
+ export(PACKAGE orocos_kdl)
+ 
+ # Generate CMake package configuration
++# Note that we generate them into temporary files in the build (BINARY_DIR)
++# directory so that subsequent builds won't accidentally find these if they
++# happen to call find_package(orocos_kdl) (this can happen with vendor packages).
+ CONFIGURE_FILE(orocos_kdl-config.cmake.in
+-  ${PROJECT_BINARY_DIR}/orocos_kdl-config.cmake @ONLY)
++  ${PROJECT_BINARY_DIR}/tmp_orocos_kdl-config.cmake @ONLY)
+ CONFIGURE_FILE(orocos_kdl-config-version.cmake.in
+-  ${PROJECT_BINARY_DIR}/orocos_kdl-config-version.cmake @ONLY)
++  ${PROJECT_BINARY_DIR}/tmp_orocos_kdl-config-version.cmake @ONLY)
+ 
+ INSTALL(FILES cmake/FindEigen3.cmake DESTINATION share/orocos_kdl/cmake)
+-INSTALL(FILES ${PROJECT_BINARY_DIR}/orocos_kdl-config.cmake DESTINATION share/orocos_kdl/cmake)
+-INSTALL(FILES ${PROJECT_BINARY_DIR}/orocos_kdl-config-version.cmake DESTINATION share/orocos_kdl/cmake)
++INSTALL(FILES ${PROJECT_BINARY_DIR}/tmp_orocos_kdl-config.cmake RENAME orocos_kdl-config.cmake DESTINATION share/orocos_kdl/cmake)
++INSTALL(FILES ${PROJECT_BINARY_DIR}/tmp_orocos_kdl-config-version.cmake RENAME orocos_kdl-config-version.cmake DESTINATION share/orocos_kdl/cmake)
+ INSTALL(EXPORT OrocosKDLTargets DESTINATION share/orocos_kdl/cmake)
+ 
+ # Generate pkg-config package configuration


### PR DESCRIPTION
When initially building the orocos_kdl_vendor package (on platforms where it actually builds), it turns out that it places a valid cmake configuration in the build directory.  In turn, that means that a subsequent rebuild will find this configuration in the build directory, and throw the rest of the logic off. This only seems to be a problem with CMake 3.29 and later, though I can't say exactly why at the moment.

Workaround this problem by writing the configuration out to a temporary file, and then moving it into the final place with the final name.

This is the final fix needed to allow us to upgrade Windows to OpenSSL 3.3.0; see https://github.com/ros-infrastructure/ros2-cookbooks/pull/68 for details.