### PR TITLE
fix: add cxx_standard to avoid c++ check error

### DIFF
--- a/orocos_kdl_vendor/CMakeLists.txt
+++ b/orocos_kdl_vendor/CMakeLists.txt
@@ -7,6 +7,11 @@ find_package(ament_cmake_vendor_package REQUIRED)
 # Set minimum version to find matching what would be built because PyKDL vendor will require it
 find_package(orocos_kdl 1.5.1 QUIET)
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
 ament_vendor(orocos_kdl_vendor
   SATISFIED ${orocos_kdl_FOUND}
   VCS_URL https://github.com/orocos/orocos_kinematics_dynamics.git
@@ -14,7 +19,7 @@ ament_vendor(orocos_kdl_vendor
   SOURCE_SUBDIR orocos_kdl
   GLOBAL_HOOK
   CMAKE_ARGS
-    -DCMAKE_CXX_STANDARD=11
+    -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
     -DENABLE_TESTS:BOOL=OFF
     -DENABLE_EXAMPLES:BOOL=OFF
   PATCHES patches

--- a/orocos_kdl_vendor/CMakeLists.txt
+++ b/orocos_kdl_vendor/CMakeLists.txt
@@ -14,6 +14,7 @@ ament_vendor(orocos_kdl_vendor
   SOURCE_SUBDIR orocos_kdl
   GLOBAL_HOOK
   CMAKE_ARGS
+    -DCMAKE_CXX_STANDARD=11
     -DENABLE_TESTS:BOOL=OFF
     -DENABLE_EXAMPLES:BOOL=OFF
   PATCHES patches

--- a/orocos_kdl_vendor/CMakeLists.txt
+++ b/orocos_kdl_vendor/CMakeLists.txt
@@ -8,7 +8,8 @@ find_package(ament_cmake_vendor_package REQUIRED)
 find_package(orocos_kdl 1.5.1 QUIET)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+  # orocos_kdl uses some deprecated APIs in C++17, so we set this to C++11
+  set(CMAKE_CXX_STANDARD 11)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 


### PR DESCRIPTION
As the solution at https://github.com/orocos/orocos_kinematics_dynamics/issues/441 , I add an arg to set the CXX_STANDARD to 11 for building project "orocos_kdl'.