### PR TITLE
fix: use fetchcontent_makeavailable to fix CMP0169

### DIFF
--- a/python_orocos_kdl_vendor/CMakeLists.txt
+++ b/python_orocos_kdl_vendor/CMakeLists.txt
@@ -55,15 +55,10 @@ macro(build_pykdl)
         ${CMAKE_CURRENT_SOURCE_DIR}/patches/0001-use-python3.patch
   )
 
-  fetchcontent_getproperties(python_orocos_kdl)
-  # TODO(sloretz) use FetchContent_MakeAvailable() when CMake 3.14 is the minimum
-  if(NOT python_orocos_kdl_POPULATED)
-    fetchcontent_populate(python_orocos_kdl)
-    # Make python_orocos_kdl targets part of this project
-    add_subdirectory(
+  fetchcontent_makeavailable(python_orocos_kdl)
+  add_subdirectory(
       "${python_orocos_kdl_SOURCE_DIR}/python_orocos_kdl"
       ${python_orocos_kdl_BINARY_DIR})
-  endif()
 
   find_package(ament_cmake_python REQUIRED)
 


### PR DESCRIPTION
Hey!

I saw @clalancette changed the minimum version of CMake to 3.20. So let's replace fetchcontent_populate to fetchcontent_makeavailable, to fix CMP0169 warning.